### PR TITLE
Modify example IAM policy

### DIFF
--- a/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json
+++ b/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json
@@ -5,7 +5,9 @@
       "Sid" : "Stmt1DescribeMountTargets",
       "Effect": "Allow",
       "Action": [
-        "elasticfilesystem:DescribeMountTargets"
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets",
+        "elasticfilesystem:CreateAccessPoint"
       ],
       "Resource": "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/file-system-ID"
     },


### PR DESCRIPTION
For https://aws.amazon.com/blogs/storage/mount-amazon-efs-file-systems-cross-account-from-amazon-eks: In step 1 of setup, we provide a link to IAM policy i.e. https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json . However the permissions provided in this link are not alone enough to successfully create access point and mount them to node.

Error faced is access denied in efs csi controller.

CORRECTION:

We need to add following permissions to the policy json at https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/examples/kubernetes/cross_account_mount/iam-policy-examples/describe-mount-target-example.json

"elasticfilesystem:DescribeFileSystems",
"elasticfilesystem:CreateAccessPoint"

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
